### PR TITLE
fix: k, . and - are just allowed in the last position of a rut. other…

### DIFF
--- a/lib/chilean/rutify.rb
+++ b/lib/chilean/rutify.rb
@@ -9,8 +9,11 @@ module Chilean
   # Chilean rut utils module
   module Rutify
     # checks if the passed value is valid as a rut character
-    def valid_rut_value?(value)
-      ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "k", "K", ".", "-"].include?(value.to_s)
+    def valid_rut_value?(value, allow_k: false)
+      base_values = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", ".", "-"]
+      base_values.push("K", "k") if allow_k
+
+      base_values.include?(value.to_s)
     end
 
     # returns the rut verifier value
@@ -115,8 +118,8 @@ module Chilean
       rut = stringify_rut(raw_rut)
       return false unless rut.present?
 
-      rut.chars.each do |i|
-        return false unless valid_rut_value?(i)
+      rut.chars.each_with_index do |c, i|
+        return false unless valid_rut_value?(c, allow_k: i == rut.length - 1)
       end
 
       true

--- a/spec/chilean/rutify_spec.rb
+++ b/spec/chilean/rutify_spec.rb
@@ -11,14 +11,27 @@ RSpec.describe Chilean::Rutify do
         expect(described_class.valid_rut_value?("y")).to eq false
         expect(described_class.valid_rut_value?("/")).to eq false
         expect(described_class.valid_rut_value?([])).to eq false
+        expect(described_class.valid_rut_value?("k")).to eq false # allow_k is false by default
       end
     end
     context "when given a valid values" do
       it "returns true" do
         expect(described_class.valid_rut_value?(0)).to eq true
         expect(described_class.valid_rut_value?("9")).to eq true
-        expect(described_class.valid_rut_value?("k")).to eq true
-        expect(described_class.valid_rut_value?("K")).to eq true
+      end
+    end
+
+    context "when allow_k is true and evaluate k" do
+      it "returns true" do
+        expect(described_class.valid_rut_value?("k", allow_k: true)).to eq true
+        expect(described_class.valid_rut_value?("K", allow_k: true)).to eq true
+      end
+    end
+
+    context "when allow_k is false and evaluate k" do
+      it "return false" do
+        expect(described_class.valid_rut_value?("k", allow_k: false)).to eq false
+        expect(described_class.valid_rut_value?("K", allow_k: false)).to eq false
       end
     end
   end
@@ -65,6 +78,7 @@ RSpec.describe Chilean::Rutify do
       it "returns false" do
         expect(described_class.valid_rut_verifier?("14.001.723-8")).to eq false
         expect(described_class.valid_rut_verifier?("14.175.644-4")).to eq false
+        expect(described_class.valid_rut_verifier?("14410191K-1")).to eq false
       end
     end
   end
@@ -129,6 +143,7 @@ RSpec.describe Chilean::Rutify do
       it "returns false" do
         expect(described_class.valid_rut?("14.001.723-8")).to eq false
         expect(described_class.valid_rut?("14.175.644-4")).to eq false
+        expect(described_class.valid_rut?("14410191K-1")).to eq false
       end
     end
   end


### PR DESCRIPTION
Hi! Thanks for doing this gem. We are using it for format and validate ruts, but recently we found that this rut was valid and allowed to be saved on our platform because the gem return true to the rut:

```fish
irb(main):015:0> Chilean::Rutify.valid_rut?("27412265k12")
=> true
irb(main):016:0> Chilean::Rutify.format_rut("27412265k12")
=> "2.741.226.5K1-2"
irb(main):017:0> 

```

This rut was clear invalid. 

So this PR includes a validation for the position of the allowed characters. "K", "k" are just allowed when it is at the final of the rut and ".", "-" are allowed just between any other characters. 

If anything of the PR is not ok, just tell me for fix it! thanks again and I hope to see this fix soon in a release!